### PR TITLE
Fixed issue where `adChoices` icon was duplicating itself on scroll

### DIFF
--- a/samples/android/RCPY/app/src/main/java/sample/com/rcpy/RecipeListAdapter.java
+++ b/samples/android/RCPY/app/src/main/java/sample/com/rcpy/RecipeListAdapter.java
@@ -102,6 +102,7 @@ class RecipeListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             btnCTA.setText(nativeAd.getAdCallToAction());
             sponsorLabel.setText(nativeAd.getSponsoredTranslation());
 
+            adChoicesContainer.removeAllViews();
             AdChoicesView adChoicesView = new AdChoicesView(context, nativeAd, true);
             adChoicesContainer.addView(adChoicesView);
 


### PR DESCRIPTION
Issue: Each time we scrolled the list, `adChoices` icon would keep duplicating itself 
![screenshot_20180723-152502](https://user-images.githubusercontent.com/16763485/43072274-f6e48c90-8e8e-11e8-87da-26b8ad1f21ee.png)
